### PR TITLE
Update URL to Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-AngularJS Translations, powered by Symfony2 ![](https://magnum.travis-ci.com/boxuk/angular-symfony-translation.svg?token=yDqUrgrJURXsZ4rVxPDd&branch=master)
+AngularJS Translations, powered by Symfony2 [![Build Status](https://travis-ci.org/boxuk/angular-symfony-translation.svg)](https://travis-ci.org/boxuk/angular-symfony-translation)
 ===========================================
 
 > Integrates BazingaJS Translation bundle with AngularJS.


### PR DESCRIPTION
Badge was 404ing as build moved to public Travis instead of Magnum CI.
