### PR TITLE
Removing bower install from postinstall script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Angular module for using translations exposed by Symfony2.",
   "main": "dist/angular-symfony-translation.js",
   "scripts": {
-    "postinstall": "node_modules/.bin/bower install",
+    "develop": "node_modules/.bin/bower install",
     "test": "gulp lint:ci && gulp karma:ci && gulp karma:integration",
     "coveralls": "cat coverage/**/lcov.info | node_modules/coveralls/bin/coveralls.js"
   },


### PR DESCRIPTION
Hi there

Since you are only using bower to install your devDependencies, it is a really bad idea to enforce everyone who wants to install your package via npm to do a bower install.

For instance: Our project does not utilize bower at all. So to use your package in a production environment we would always need to install bower AND your devDependencies.

So i changed the postinstall script to develop.

Hope my explanantion makes sense!

Thanks
